### PR TITLE
Adjust for py3

### DIFF
--- a/bin/crm
+++ b/bin/crm
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # crmsh, command line interface for Linux HA clusters
 # Copyright (C) 2008-2015 Dejan Muhamedagic <dmuhamedagic@suse.de>
@@ -21,15 +21,7 @@
 
 from __future__ import unicode_literals
 import sys
-from distutils import version
 
-minimum_version = '2.6'
-v_min = version.StrictVersion(minimum_version)
-v_this = version.StrictVersion(sys.version[:3])
-if v_min > v_this:
-    sys.stderr.write("abort: minimum python version support is %s\n" %
-                     minimum_version)
-    sys.exit(-1)
 
 try:
     try:

--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2016 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 #
@@ -14,10 +12,6 @@ from __future__ import unicode_literals
 # TODO: Make csync2 usage optional
 # TODO: Configuration file for bootstrap?
 
-from builtins import next
-from builtins import str
-from builtins import range
-from builtins import object
 import os
 import sys
 import random

--- a/crmsh/cache.py
+++ b/crmsh/cache.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 #

--- a/crmsh/cibconfig.py
+++ b/crmsh/cibconfig.py
@@ -1,13 +1,6 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-from past.builtins import basestring
-from builtins import object
 import copy
 from lxml import etree
 import os

--- a/crmsh/cibstatus.py
+++ b/crmsh/cibstatus.py
@@ -1,9 +1,6 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 
-from builtins import object
 import os
 from lxml import etree
 from . import tmpfiles

--- a/crmsh/cibverify.py
+++ b/crmsh/cibverify.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # Copyright (C) 2014 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 

--- a/crmsh/clidisplay.py
+++ b/crmsh/clidisplay.py
@@ -4,7 +4,6 @@
 """
 Display output for various syntax elements.
 """
-from __future__ import unicode_literals
 
 from contextlib import contextmanager
 

--- a/crmsh/cliformat.py
+++ b/crmsh/cliformat.py
@@ -1,8 +1,6 @@
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 
-from builtins import range
 from . import constants
 from . import clidisplay
 from . import utils

--- a/crmsh/cmd_status.py
+++ b/crmsh/cmd_status.py
@@ -1,9 +1,7 @@
-from __future__ import unicode_literals
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 
-from builtins import object
 import re
 from . import clidisplay
 from . import utils

--- a/crmsh/command.py
+++ b/crmsh/command.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
@@ -9,11 +6,6 @@ from __future__ import unicode_literals
 #   Mostly, what these functions do is store extra metadata
 #   inside the functions.
 
-from builtins import str
-from builtins import range
-from past.builtins import basestring
-from builtins import object
-from past.utils import old_div
 import inspect
 from . import help as help_module
 from . import ui_utils

--- a/crmsh/command.py
+++ b/crmsh/command.py
@@ -98,7 +98,7 @@ def skill_level(new_level):
         def do_rmrf(self, cmd, args):
             ...
     '''
-    if isinstance(new_level, basestring):
+    if isinstance(new_level, str):
         levels = {'operator': 0, 'administrator': 1, 'expert': 2}
         if new_level.lower() not in levels:
             raise ValueError("Unknown skill level: " + new_level)
@@ -452,7 +452,7 @@ Examples:
         def get_if_command(attr):
             "Return the named attribute if it's a command"
             child = getattr(cls, attr)
-            return child if attr.startswith('do_') and inspect.ismethod(child) else None
+            return child if attr.startswith('do_') and inspect.isfunction(child) else None
 
         def add_aliases(children, info):
             "Add any aliases for command to child map"

--- a/crmsh/completers.py
+++ b/crmsh/completers.py
@@ -1,10 +1,8 @@
-from __future__ import unicode_literals
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
 # Helper completers
 
-from builtins import filter
 from . import xmlutil
 
 

--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -269,7 +269,7 @@ def _stringify(val):
         return 'true'
     elif val is False:
         return 'false'
-    elif isinstance(val, basestring):
+    elif isinstance(val, str):
         return val
     else:
         return str(val)

--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -3,13 +3,7 @@
 '''
 Holds user-configurable options.
 '''
-from __future__ import unicode_literals
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-from past.builtins import basestring
-from builtins import object
 import os
 import re
 try:

--- a/crmsh/config.py
+++ b/crmsh/config.py
@@ -439,11 +439,8 @@ def load_version():
     version = 'dev'
     versioninfo_file = os.path.join(path.sharedir, 'version')
     if os.path.isfile(versioninfo_file):
-        v = open(versioninfo_file)
-        try:
-            version = v.next().strip() or version
-        except StopIteration:
-            pass
+        with open(versioninfo_file) as f:
+            version = f.read().strip() or version
     return version
 
 

--- a/crmsh/constants.py
+++ b/crmsh/constants.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -4,12 +4,7 @@
 Functions that abstract creating and editing the corosync.conf
 configuration file, and also the corosync-* utilities.
 '''
-from __future__ import print_function
-from __future__ import unicode_literals
 
-from builtins import str
-from builtins import range
-from builtins import object
 import os
 import re
 import socket

--- a/crmsh/crm_gv.py
+++ b/crmsh/crm_gv.py
@@ -1,9 +1,6 @@
-from __future__ import unicode_literals
 # Copyright (C) 2013 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 
-from builtins import range
-from builtins import object
 import re
 from . import config
 from . import tmpfiles

--- a/crmsh/crm_pssh.py
+++ b/crmsh/crm_pssh.py
@@ -10,11 +10,7 @@ For each node, this essentially does an "ssh host -l user prog [arg0] [arg1]
 directory.  Each output file in that directory will be named by the
 corresponding remote node's hostname or IP address.
 """
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
-from past.utils import old_div
 import os
 import glob
 

--- a/crmsh/handles.py
+++ b/crmsh/handles.py
@@ -1,9 +1,6 @@
-from __future__ import unicode_literals
 # Copyright (C) 2015 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
-from builtins import str
-from builtins import object
 import re
 
 

--- a/crmsh/help.py
+++ b/crmsh/help.py
@@ -24,10 +24,7 @@ Help for the level itself is like this:
 
 [[cmdhelp_<level>,<short help text>]]
 '''
-from __future__ import unicode_literals
 
-from builtins import str
-from builtins import object
 import os
 import re
 from .utils import page_string

--- a/crmsh/history.py
+++ b/crmsh/history.py
@@ -1,14 +1,7 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013-2016 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-from builtins import range
-from builtins import object
 import os
 import time
 import re

--- a/crmsh/idmgmt.py
+++ b/crmsh/idmgmt.py
@@ -1,10 +1,8 @@
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 #
 # Make sure that ids are unique.
 
-from builtins import range
 from . import constants
 import copy
 from .msg import common_error, id_used_err

--- a/crmsh/log_patterns.py
+++ b/crmsh/log_patterns.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # Copyright (C) 2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 #

--- a/crmsh/logparser.py
+++ b/crmsh/logparser.py
@@ -1,10 +1,6 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2016 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
-from builtins import zip
-from builtins import object
 import bz2
 import gzip
 import re

--- a/crmsh/logtime.py
+++ b/crmsh/logtime.py
@@ -4,7 +4,6 @@
 """
 Helpers for handling log timestamps.
 """
-from __future__ import unicode_literals
 
 import re
 import time

--- a/crmsh/main.py
+++ b/crmsh/main.py
@@ -1,9 +1,6 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 
-from builtins import str
 import sys
 import os
 import atexit

--- a/crmsh/main.py
+++ b/crmsh/main.py
@@ -216,7 +216,7 @@ def render_prompt(context):
         # seems the color prompt messes it up
         promptstr = "crm(%s/%s)%s# " % (cib_prompt(), utils.this_node(), context.prompt())
         constants.prompt = promptstr
-        if clidisplay.colors_enabled():
+        if not clidisplay.colors_enabled():
             rendered_prompt = term.render(clidisplay.prompt(promptstr))
         else:
             rendered_prompt = promptstr

--- a/crmsh/msg.py
+++ b/crmsh/msg.py
@@ -1,11 +1,6 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 
-from builtins import input
-from past.builtins import basestring
-from builtins import object
 import sys
 from . import config
 from . import clidisplay

--- a/crmsh/options.py
+++ b/crmsh/options.py
@@ -4,7 +4,6 @@
 '''
 Session-only options (not saved).
 '''
-from __future__ import unicode_literals
 
 interactive = False
 batch = False

--- a/crmsh/ordereddict.py
+++ b/crmsh/ordereddict.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # Copyright (c) 2009 Raymond Hettinger
 #
 # Permission is hereby granted, free of charge, to any person
@@ -21,7 +20,6 @@ from __future__ import unicode_literals
 #     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 #     OTHER DEALINGS IN THE SOFTWARE.
 
-from builtins import zip
 try:
     from collections import OrderedDict
 except ImportError:

--- a/crmsh/orderedset.py
+++ b/crmsh/orderedset.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2009 Raymond Hettinger
 
 #                          *** MIT License ***
@@ -23,8 +21,6 @@ from __future__ import unicode_literals
 
 # {{{ http://code.activestate.com/recipes/576694/ (r7)
 
-from builtins import next
-from builtins import range
 import collections
 
 KEY, PREV, NEXT = list(range(3))

--- a/crmsh/pacemaker.py
+++ b/crmsh/pacemaker.py
@@ -1,10 +1,6 @@
-from __future__ import unicode_literals
 # Copyright (C) 2009 Yan Gao <ygao@novell.com>
 # See COPYING for license information.
 
-from builtins import str
-from past.builtins import basestring
-from builtins import object
 import os
 import tempfile
 import copy

--- a/crmsh/parse.py
+++ b/crmsh/parse.py
@@ -1,12 +1,7 @@
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013-2016 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
-from builtins import str
-from builtins import range
-from past.builtins import basestring
-from builtins import object
 import shlex
 import re
 import inspect

--- a/crmsh/ra.py
+++ b/crmsh/ra.py
@@ -1,10 +1,6 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 
-from past.builtins import basestring
-from builtins import object
 import os
 import subprocess
 import copy

--- a/crmsh/rsctest.py
+++ b/crmsh/rsctest.py
@@ -1,9 +1,6 @@
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 
-from builtins import str
-from builtins import object
 import os
 import sys
 from .msg import common_err, common_debug, common_warn, common_info

--- a/crmsh/schema.py
+++ b/crmsh/schema.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # Copyright (C) 2012 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 

--- a/crmsh/scripts.py
+++ b/crmsh/scripts.py
@@ -1,15 +1,6 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2015 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import next
-from builtins import hex
-from builtins import str
-from past.builtins import basestring
-from builtins import object
 import os
 import re
 import subprocess

--- a/crmsh/template.py
+++ b/crmsh/template.py
@@ -1,10 +1,6 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 
-from builtins import range
-from builtins import object
 import os
 import re
 from . import config

--- a/crmsh/term.py
+++ b/crmsh/term.py
@@ -1,10 +1,6 @@
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 
-from builtins import zip
-from builtins import range
-from builtins import object
 import sys
 import re
 

--- a/crmsh/term.py
+++ b/crmsh/term.py
@@ -75,7 +75,7 @@ _ANSICOLORS = "BLACK RED GREEN YELLOW BLUE MAGENTA CYAN WHITE".split()
 
 def _tigetstr(cap_name):
     import curses
-    cap = curses.tigetstr(cap_name) or ''
+    cap = str(curses.tigetstr(cap_name)) or ''
 
     # String capabilities can include "delays" of the form "$<2>".
     # For any modern terminal, we should be able to just ignore
@@ -111,19 +111,19 @@ def _lookup_caps():
         (attrib, cap_name) = capability.split('=')
         setattr(colors, attrib, _tigetstr(cap_name) or '')
     # Colors
-    set_fg = _tigetstr('setf')
+    set_fg = bytes(_tigetstr('setf'), 'latin-1')
     if set_fg:
         for i, color in zip(list(range(len(_COLORS))), _COLORS):
             setattr(colors, color, curses.tparm(set_fg, i) or '')
-    set_fg_ansi = _tigetstr('setaf')
+    set_fg_ansi = bytes(_tigetstr('setaf'), 'latin-1')
     if set_fg_ansi:
         for i, color in zip(list(range(len(_ANSICOLORS))), _ANSICOLORS):
             setattr(colors, color, curses.tparm(set_fg_ansi, i) or '')
-    set_bg = _tigetstr('setb')
+    set_bg = bytes(_tigetstr('setb'), 'latin-1')
     if set_bg:
         for i, color in zip(list(range(len(_COLORS))), _COLORS):
             setattr(colors, 'BG_'+color, curses.tparm(set_bg, i) or '')
-    set_bg_ansi = _tigetstr('setab')
+    set_bg_ansi = bytes(_tigetstr('setab'), 'latin-1')
     if set_bg_ansi:
         for i, color in zip(list(range(len(_ANSICOLORS))), _ANSICOLORS):
             setattr(colors, 'BG_'+color, curses.tparm(set_bg_ansi, i) or '')

--- a/crmsh/tmpfiles.py
+++ b/crmsh/tmpfiles.py
@@ -4,7 +4,6 @@
 '''
 Files added to tmpfiles are removed at program exit.
 '''
-from __future__ import unicode_literals
 
 import os
 import shutil

--- a/crmsh/ui_assist.py
+++ b/crmsh/ui_assist.py
@@ -1,9 +1,6 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2014 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
-from builtins import zip
 from . import utils
 from . import command
 from . import completers as compl

--- a/crmsh/ui_cib.py
+++ b/crmsh/ui_cib.py
@@ -1,10 +1,7 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
-from builtins import str
 import os
 import glob
 from . import command

--- a/crmsh/ui_cibstatus.py
+++ b/crmsh/ui_cibstatus.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.

--- a/crmsh/ui_cluster.py
+++ b/crmsh/ui_cluster.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.

--- a/crmsh/ui_configure.py
+++ b/crmsh/ui_configure.py
@@ -1,10 +1,7 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
-from builtins import object
 import time
 from . import command
 from . import completers as compl

--- a/crmsh/ui_context.py
+++ b/crmsh/ui_context.py
@@ -1,9 +1,6 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
-from builtins import object
 import shlex
 import sys
 from . import config

--- a/crmsh/ui_corosync.py
+++ b/crmsh/ui_corosync.py
@@ -1,9 +1,6 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
-from builtins import str
 import os
 from . import command
 from . import completers

--- a/crmsh/ui_history.py
+++ b/crmsh/ui_history.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.

--- a/crmsh/ui_maintenance.py
+++ b/crmsh/ui_maintenance.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # Copyright (C) 2014 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 

--- a/crmsh/ui_node.py
+++ b/crmsh/ui_node.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.

--- a/crmsh/ui_options.py
+++ b/crmsh/ui_options.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.

--- a/crmsh/ui_ra.py
+++ b/crmsh/ui_ra.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.

--- a/crmsh/ui_report.py
+++ b/crmsh/ui_report.py
@@ -1,10 +1,7 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
-from builtins import str
 import os
 import subprocess
 from signal import signal, SIGPIPE, SIG_DFL

--- a/crmsh/ui_resource.py
+++ b/crmsh/ui_resource.py
@@ -1,9 +1,7 @@
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
-from builtins import filter
 from . import command
 from . import completers as compl
 from . import constants

--- a/crmsh/ui_root.py
+++ b/crmsh/ui_root.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.

--- a/crmsh/ui_script.py
+++ b/crmsh/ui_script.py
@@ -1,12 +1,7 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
 
-from builtins import str
-from past.builtins import basestring
-from builtins import object
 import sys
 
 try:

--- a/crmsh/ui_site.py
+++ b/crmsh/ui_site.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.

--- a/crmsh/ui_template.py
+++ b/crmsh/ui_template.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.

--- a/crmsh/ui_utils.py
+++ b/crmsh/ui_utils.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.

--- a/crmsh/userdir.py
+++ b/crmsh/userdir.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 # Copyright (C) 2013 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1394,7 +1394,7 @@ def get_pcmk_version(dflt):
             common_err("%s exited with %d [err: %s][out: %s]" % (cmd, rc, err, s))
         else:
             common_debug("pacemaker version: [err: %s][out: %s]" % (err, s))
-            if err.startswith("CRM Version:"):
+            if err.startswith(b"CRM Version:"):
                 version = s.split()[0]
             else:
                 version = s.split()[2]

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1473,8 +1473,9 @@ def is_min_pcmk_ver(min_ver, cib_f=None):
                          (constants.pcmk_version, cib_f))
         else:
             constants.pcmk_version = get_pcmk_version("1.1.11")
-    from distutils.version import LooseVersion
-    return LooseVersion(constants.pcmk_version) >= LooseVersion(min_ver)
+    #from distutils.version import LooseVersion
+    #return LooseVersion(constants.pcmk_version) >= LooseVersion(min_ver)
+    return True
 
 
 def is_pcmk_118(cib_f=None):

--- a/crmsh/utils.py
+++ b/crmsh/utils.py
@@ -1,17 +1,6 @@
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # See COPYING for license information.
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import input
-from builtins import map
-from builtins import str
-from builtins import range
-from builtins import object
-from past.utils import old_div
 import os
 import sys
 from tempfile import mkstemp

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -1,13 +1,7 @@
-from __future__ import print_function
-from __future__ import unicode_literals
 # Copyright (C) 2008-2011 Dejan Muhamedagic <dmuhamedagic@suse.de>
 # Copyright (C) 2016 Kristoffer Gronlund <kgronlund@suse.com>
 # See COPYING for license information.
 
-from builtins import zip
-from builtins import str
-from past.builtins import basestring
-from builtins import object
 import os
 import subprocess
 from lxml import etree, doctestcompare

--- a/crmsh/xmlutil.py
+++ b/crmsh/xmlutil.py
@@ -820,7 +820,7 @@ def get_rsc_operations(rsc_node):
 def make_sort_map(*order):
     m = {}
     for i, o in enumerate(order):
-        if isinstance(o, basestring):
+        if isinstance(o, str):
             m[o] = i
         else:
             for k in o:


### PR DESCRIPTION
hi krig:
   I'm trying to do the switching work these days.
   changes include:
   1) change bin/crm, drop the limit for py3
   2) drop the codes about future/past/buildins
   3) disable the colors because for now I don't know how to change it;
      It's not easy for me to debug on term.py;
      alternatively, can we use this for colors? https://pypi.python.org/pypi/colorama
      It seems easy to read and change, not depend on curses:)
   4) LooseVersion in distuils.version maybe have error running at python3 

Apply these commits, typping "crm" and "Tab" can see all the root sub-levels 

Above is just a try and practice for myself, I think it will be fine if we could have a new starting point without "futer/past/buildins" codes :)
Or, it's still ok starting from here sure
    