### PR TITLE
implement logic for lms and ffsplit

### DIFF
--- a/crmsh/bootstrap.py
+++ b/crmsh/bootstrap.py
@@ -1730,6 +1730,9 @@ def join_cluster(seed_host):
         # get a list of nodes, excluding remote nodes
         nodelist = None
         loop_count = 0
+        device_votes = 0
+        nodecount = 0
+        expected_votes = 0
         while True:
             rc, nodelist_text = utils.get_stdout("cibadmin -Ql --xpath '/cib/status/node_state'")
             if rc == 0:
@@ -1751,25 +1754,53 @@ def join_cluster(seed_host):
         # so that we can ask the cluster for the current membership list
         # Have to check if a qnetd device is configured and increase
         # expected_votes in that case
-        qnetd_votes = 1 if corosync.get_value("quorum.device.model") == "net" else 0
+        use_qdevice = 1 if corosync.get_value("quorum.device.model") == "net" else 0
         if nodelist is None:
-            nodecount = 0
             for v in corosync.get_values("quorum.expected_votes"):
-                nodecount = int(v) + 1 + qnetd_votes
-                corosync.set_value("quorum.expected_votes", str(nodecount))
-                corosync.set_value("quorum.two_node", 1 if nodecount == 2 else 0)
+                expected_votes = v
+                #for node >= 2, expected_votes = nodecount + device_votes
+                #asume nodecount is N, for ffsplit, qdevice only has one vote
+                #which means that device_votes is 1, ie:expected_votes = N + 1;
+                #while for lms, qdevice has N - 1 votes, ie: expected_votes = N + (N - 1)
+                #and update quorum.device.net.algorithm based on device_votes
+
+                if corosync.get_value("quorum.device.net.algorithm") == "lms":
+                    device_votes = int((expected_votes - 1) / 2)
+                    nodecount = expected_votes - device_votes
+                    #as nodecount will increase 1, and device_votes is nodecount - 1
+                    #device_votes also increase 1
+                    device_votes += 1
+                elif corosync.get_value("quorum.device.net.algorithm") == "ffsplit":
+                    device_votes = 1
+                    nodecount = expected_votes - device_votes
+                elif use_qdevice == 0:
+                    device_votes = 0
+                    nodecount = v
+
+                nodecount += 1
+                expected_votes = nodecount + device_votes
+                corosync.set_value("quorum.expected_votes", str(expected_votes))
         else:
-            nodecount = len(nodelist) + qnetd_votes
-            if corosync.get_value("quorum.expected_votes"):
-                corosync.set_value("quorum.expected_votes", str(nodecount))
-            corosync.set_value("quorum.two_node", 1 if nodecount == 2 else 0)
-        if qnetd_votes > 0 and nodecount > 0:
-            device_votes = 1
+            nodecount = len(nodelist)
+            expected_votes = 0
+            #for node >= 2, expected_votes = nodecount + device_votes
+            #asume nodecount is N, for ffsplit, qdevice only has one vote
+            #which means that device_votes is 1, ie:expected_votes = N + 1;
+            #while for lms, qdevice has N - 1 votes, ie: expected_votes = N + (N - 1)
+            if corosync.get_value("quorum.device.net.algorithm") == "ffsplit":
+                device_votes = 1
             if corosync.get_value("quorum.device.net.algorithm") == "lms":
                 device_votes = nodecount - 1
-            elif nodecount == 1:
-                device_votes = 0
+
+            expected_votes = nodecount + device_votes
+
+            if corosync.get_value("quorum.expected_votes"):
+                corosync.set_value("quorum.expected_votes", str(expected_votes))
+        if use_qdevice == 0:
+            corosync.set_value("quorum.two_node", 1 if expected_votes == 2 else 0)
+        if use_qdevice:
             corosync.set_value("quorum.device.votes", device_votes)
+
         csync2_update(corosync.conf())
     update_expected_votes()
 
@@ -1912,19 +1943,34 @@ def remove_node_from_cluster():
         corosync.del_node(node)
 
     # Decrement expected_votes in corosync.conf
-    qnetd_votes = 1 if "net" in corosync.get_values("quorum.device.model") else 0
+    use_qdevice = 1 if "net" in corosync.get_values("quorum.device.model") else 0
     for vote in corosync.get_values("quorum.expected_votes"):
-        new_quorum = int(vote) - 1 + qnetd_votes
-        corosync.set_value("quorum.expected_votes", str(new_quorum))
-        corosync.set_value("quorum.two_node", 1 if new_quorum == 2 else 0)
-        if qnetd_votes > 0:
-            new_nodecount = int(vote) - 1
-            device_votes = 1
+        quorum = int(vote)
+        new_quorum = quorum - 1
+        if use_qdevice > 0:
+            new_nodecount = 0
+            device_votes = 0
+            nodecount = 0
+
             if corosync.get_value("quorum.device.net.algorithm") == "lms":
+                nodecount = int((quorum + 1)/2)
+                new_nodecount = nodecount - 1
                 device_votes = new_nodecount - 1
-            elif new_nodecount == 1:
+
+            elif corosync.get_value("quorum.device.net.algorithm") == "ffsplit":
+                device_votes = 1
+                nodecount = quorum - device_votes
+                new_nodecount = nodecount - 1
+
+            if new_nodecount == 1:
                 device_votes = 0
+
             corosync.set_value("quorum.device.votes", device_votes)
+            new_quorum = new_nodecount + device_votes
+
+        if use_qdevice == 0:
+            corosync.set_value("quorum.two_node", 1 if new_quorum == 2 else 0)
+        corosync.set_value("quorum.expected_votes", str(new_quorum))
 
     status("Propagating configuration changes across the remaining nodes")
     csync2_update(CSYNC2_CFG)

--- a/crmsh/corosync.py
+++ b/crmsh/corosync.py
@@ -396,6 +396,8 @@ def add_node_ucast(IParray, node_name=None):
 
     num_nodes = p.count('nodelist.node')
     p.set('quorum.two_node', '1' if num_nodes == 2 else '0')
+    if p.get("quorum.device.model") == "net":
+        p.set('quorum.two_node', '0')
 
     f = open(conf(), 'w')
     f.write(p.to_string())
@@ -444,6 +446,8 @@ def add_node(addr, name=None):
 
     num_nodes = p.count('nodelist.node')
     p.set('quorum.two_node', '1' if num_nodes == 2 else '0')
+    if p.get("quorum.device.model") == "net":
+        p.set('quorum.two_node', '0')
 
     f = open(conf(), 'w')
     f.write(p.to_string())
@@ -475,6 +479,8 @@ def del_node(addr):
 
     num_nodes = p.count('nodelist.node')
     p.set('quorum.two_node', '1' if num_nodes == 2 else '0')
+    if p.get("quorum.device.model") == "net":
+        p.set('quorum.two_node', '0')
 
     f = open(conf(), 'w')
     f.write(p.to_string())
@@ -603,7 +609,7 @@ def create_configuration(clustername="hacluster",
     expected_votes: 1
     two_node: 0
     device {
-      votes: 1
+      votes: 0
       model: net
       net {
         tls: off


### PR DESCRIPTION
for node >= 2, expected_votes = nodecount + device_votes
asume nodecount is N,
for ffsplit, qdevice only has one vote,
which means that device_votes is 1, ie:
    expected_votes = N + 1

while for lms, qdevice has N - 1 votes, ie:
    expected_votes = N + (N - 1)

for node == 1, we set device_votes = 0 to make corosync run, which
will also follow:
    expected_votes = nodecount + device_votes

and also device_votes must be less than expected_votes for corosync
to run, and if device_votes > 0, to make corosync run, it must follow:
    expected_votes - device_votes > 2

at last we update quorum.device.net.algorithm based on device_votes